### PR TITLE
Fix: missing annotations for configmap takeover

### DIFF
--- a/api/bdc/common/types.go
+++ b/api/bdc/common/types.go
@@ -144,3 +144,10 @@ const (
 	ApplicationFinalPhaseException ApplicationFinalPhase = "exception"
 	ApplicationFinalPhaseStopping  ApplicationFinalPhase = "stopping"
 )
+
+type CtxSettingCreationSource string
+
+const (
+	CtxSettingCreatedViaSystem   CtxSettingCreationSource = "system"
+	CtxSettingCreatedViaManually CtxSettingCreationSource = "manual"
+)

--- a/pkg/controllers/bdc/constants/annotations.go
+++ b/pkg/controllers/bdc/constants/annotations.go
@@ -27,12 +27,13 @@ const (
 	// AnnotationCtxSettingAdopt is the annotation which describe what is the capability used for in a Context Setting Object
 	AnnotationCtxSettingAdopt = "setting.ctx.bdc.kdp.io/adopt"
 
-	AnnotationBDCDefaultNamespace     = "bdc.kdp.io/namespace"
-	AnnotationBDCAlias                = "bdc.kdp.io/alias"
-	AnnotationBDCDescription          = "bdc.kdp.io/description"
-	AnnotationBDCUpdatedTime          = "bdc.kdp.io/updateTime"
-	AnnotationBDCAppliedConfiguration = "bdc.kdp.io/applied-configuration"
-	AnnotationCtxSettingOrigin        = "setting.ctx.bdc.kdp.io/origin"
+	AnnotationBDCDefaultNamespace           = "bdc.kdp.io/namespace"
+	AnnotationBDCAlias                      = "bdc.kdp.io/alias"
+	AnnotationBDCDescription                = "bdc.kdp.io/description"
+	AnnotationBDCUpdatedTime                = "bdc.kdp.io/updateTime"
+	AnnotationBDCAppliedConfiguration       = "bdc.kdp.io/applied-configuration"
+	AnnotationCtxSettingOrigin              = "setting.ctx.bdc.kdp.io/origin"
+	AnnotationCtxSettingReferencedConfigMap = "setting.ctx.bdc.kdp.io/referenced-configmap"
 
 	// FinalizerResourceTracker finalizer for gc
 	FinalizerResourceTracker = "bdc.kdp.io/resource-tracker-finalizer"

--- a/pkg/controllers/configmap/syncer.go
+++ b/pkg/controllers/configmap/syncer.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"kdp-oam-operator/api/bdc/common"
 	bdcv1alpha1 "kdp-oam-operator/api/bdc/v1alpha1"
 	ctrOptions "kdp-oam-operator/cmd/bdc/controller/options"
 	"kdp-oam-operator/pkg/controllers/bdc/constants"
@@ -170,11 +171,13 @@ func (s *CMSyncer) SyncConfigMapToContextSetting(item *coreV1.ConfigMap) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: fmt.Sprintf("%s-%s", item.Namespace, item.Name),
 			Annotations: map[string]string{
-				constants.AnnotationCtxSettingSource:    "config",
-				constants.AnnotationCtxSettingAdopt:     "true",
-				constants.AnnotationBDCDefaultNamespace: item.Namespace,
-				constants.AnnotationBDCName:             referencedBDCName,
-				constants.AnnotationOrgName:             referencedBDCOrgName,
+				constants.AnnotationCtxSettingOrigin:              string(common.CtxSettingCreatedViaSystem),
+				constants.AnnotationCtxSettingSource:              "config",
+				constants.AnnotationCtxSettingAdopt:               "true",
+				constants.AnnotationBDCDefaultNamespace:           item.Namespace,
+				constants.AnnotationBDCName:                       referencedBDCName,
+				constants.AnnotationOrgName:                       referencedBDCOrgName,
+				constants.AnnotationCtxSettingReferencedConfigMap: item.Name,
 			},
 			Labels: map[string]string{
 				constants.AnnotationBDCName: referencedBDCName,


### PR DESCRIPTION
<!--

### Before you open your PR

- [Signed-off your commits](https://github.com/apps/dco/) (otherwise the DCO check will fail).
- Used [a conventional commit message](https://www.conventionalcommits.org/en/v1.0.0/).

### When you open your PR

- PR title format should also conform to [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
- "Fixes #" is in both the PR title (for release notes) and this description (to automatically link and close the issue).
- Create the PR as draft.
- Once builds are green, mark your PR "Ready for review".

When changes are requested, please address them and then dismiss the review to get it reviewed again.

-->

### Description of your changes

<!-- Does this PR fix an issue -->

<!-- TODO: Say why you made your changes. -->
- add annotations `setting.ctx.bdc.kdp.io/origin` for configmap takeover
<!-- TODO: Attach screenshots if you changed the UI. -->

### How has this code been tested
<!-- TODO: Say how you tested your changes. -->

